### PR TITLE
feat(clients): #5 client management CRUD

### DIFF
--- a/api/clients.ts
+++ b/api/clients.ts
@@ -1,0 +1,168 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import pool from './_lib/db.js'
+
+async function getUserId(auth0Id: string): Promise<string | null> {
+  const result = await pool.query(
+    'SELECT id FROM profiles WHERE auth0_id = $1',
+    [auth0Id],
+  )
+  return result.rows[0]?.id ?? null
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const auth0_id =
+    req.method === 'GET' ? (req.query.auth0_id as string) : req.body?.auth0_id
+
+  if (!auth0_id) {
+    return res.status(400).json({ error: 'auth0_id is required' })
+  }
+
+  const userId = await getUserId(auth0_id)
+  if (!userId) {
+    return res.status(404).json({ error: 'User not found' })
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const result = await pool.query(
+        'SELECT * FROM clients WHERE user_id = $1 ORDER BY created_at DESC',
+        [userId],
+      )
+      return res.status(200).json({ clients: result.rows })
+    } catch (error) {
+      return res.status(500).json({
+        error: 'Failed to fetch clients',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+  }
+
+  if (req.method === 'POST') {
+    const {
+      is_business,
+      business_name,
+      first_name,
+      last_name,
+      email,
+      country,
+      street,
+      city,
+      zip,
+      vat_number,
+    } = req.body
+
+    if (!country || !street || !city || !zip) {
+      return res
+        .status(400)
+        .json({ error: 'country, street, city, and zip are required' })
+    }
+
+    try {
+      const result = await pool.query(
+        `INSERT INTO clients (user_id, is_business, business_name, first_name, last_name, email, country, street, city, zip, vat_number)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+         RETURNING *`,
+        [
+          userId,
+          is_business ?? false,
+          business_name,
+          first_name,
+          last_name,
+          email,
+          country,
+          street,
+          city,
+          zip,
+          vat_number,
+        ],
+      )
+      return res.status(201).json({ client: result.rows[0] })
+    } catch (error) {
+      return res.status(500).json({
+        error: 'Failed to create client',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+  }
+
+  if (req.method === 'PUT') {
+    const {
+      id,
+      is_business,
+      business_name,
+      first_name,
+      last_name,
+      email,
+      country,
+      street,
+      city,
+      zip,
+      vat_number,
+    } = req.body
+
+    if (!id) {
+      return res.status(400).json({ error: 'id is required' })
+    }
+
+    try {
+      const result = await pool.query(
+        `UPDATE clients
+         SET is_business = $3, business_name = $4, first_name = $5, last_name = $6,
+             email = $7, country = $8, street = $9, city = $10, zip = $11, vat_number = $12
+         WHERE id = $1 AND user_id = $2
+         RETURNING *`,
+        [
+          id,
+          userId,
+          is_business ?? false,
+          business_name,
+          first_name,
+          last_name,
+          email,
+          country,
+          street,
+          city,
+          zip,
+          vat_number,
+        ],
+      )
+
+      if (result.rows.length === 0) {
+        return res.status(404).json({ error: 'Client not found' })
+      }
+      return res.status(200).json({ client: result.rows[0] })
+    } catch (error) {
+      return res.status(500).json({
+        error: 'Failed to update client',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+  }
+
+  if (req.method === 'DELETE') {
+    const { id } = req.body
+
+    if (!id) {
+      return res.status(400).json({ error: 'id is required' })
+    }
+
+    try {
+      const result = await pool.query(
+        'DELETE FROM clients WHERE id = $1 AND user_id = $2 RETURNING id',
+        [id, userId],
+      )
+
+      if (result.rows.length === 0) {
+        return res.status(404).json({ error: 'Client not found' })
+      }
+      return res.status(200).json({ deleted: true })
+    } catch (error) {
+      return res.status(500).json({
+        error: 'Failed to delete client',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -52,7 +52,7 @@ describe('Routing', () => {
 
   it('renders Clients at /clients', () => {
     renderRoute('/clients')
-    expect(screen.getByText('Clients')).toBeInTheDocument()
+    expect(screen.getByText('Loading clients...')).toBeInTheDocument()
   })
 
   it('renders NotFound for unknown routes', () => {

--- a/src/components/ClientForm.tsx
+++ b/src/components/ClientForm.tsx
@@ -1,0 +1,196 @@
+import { useState } from 'react'
+import type { ClientFormData } from '../hooks/useClients'
+import { emptyClientForm } from '../hooks/useClients'
+import { COUNTRIES } from '../utils/countries'
+import { Input } from './ui/input'
+import { Label } from './ui/label'
+import { Button } from './ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './ui/select'
+
+interface ClientFormProps {
+  initial?: ClientFormData
+  onSubmit: (data: ClientFormData) => Promise<void>
+  onCancel: () => void
+  submitLabel?: string
+}
+
+export default function ClientForm({
+  initial,
+  onSubmit,
+  onCancel,
+  submitLabel = 'Save',
+}: ClientFormProps) {
+  const [form, setForm] = useState<ClientFormData>(
+    () => initial ?? { ...emptyClientForm },
+  )
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  function handleChange(field: keyof ClientFormData, value: string | boolean) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    setFormError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setFormError(null)
+
+    if (!form.country || !form.street || !form.city || !form.zip) {
+      setFormError('Country, street, city, and zip are required.')
+      return
+    }
+    if (form.is_business && !form.business_name) {
+      setFormError('Business name is required for business clients.')
+      return
+    }
+    if (!form.is_business && !form.first_name) {
+      setFormError('First name is required.')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await onSubmit(form)
+    } catch {
+      setFormError('Failed to save client.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="is_business"
+          checked={form.is_business}
+          onChange={(e) => handleChange('is_business', e.target.checked)}
+          className="rounded"
+        />
+        <Label htmlFor="is_business">Client is registered as a business</Label>
+      </div>
+
+      {form.is_business ? (
+        <div className="space-y-2">
+          <Label htmlFor="business_name">Business name *</Label>
+          <Input
+            id="business_name"
+            value={form.business_name}
+            onChange={(e) => handleChange('business_name', e.target.value)}
+            required
+          />
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="first_name">First name *</Label>
+            <Input
+              id="first_name"
+              value={form.first_name}
+              onChange={(e) => handleChange('first_name', e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="last_name">Last name *</Label>
+            <Input
+              id="last_name"
+              value={form.last_name}
+              onChange={(e) => handleChange('last_name', e.target.value)}
+              required
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="client_country">Country *</Label>
+        <Select
+          value={form.country}
+          onValueChange={(value) => handleChange('country', value ?? '')}
+        >
+          <SelectTrigger id="client_country">
+            <SelectValue placeholder="Select a country" />
+          </SelectTrigger>
+          <SelectContent>
+            {COUNTRIES.map((c) => (
+              <SelectItem key={c} value={c}>
+                {c}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="street">Street *</Label>
+        <Input
+          id="street"
+          value={form.street}
+          onChange={(e) => handleChange('street', e.target.value)}
+          required
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="client_city">City *</Label>
+          <Input
+            id="client_city"
+            value={form.city}
+            onChange={(e) => handleChange('city', e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="client_zip">Zip / Postcode *</Label>
+          <Input
+            id="client_zip"
+            value={form.zip}
+            onChange={(e) => handleChange('zip', e.target.value)}
+            required
+          />
+        </div>
+      </div>
+
+      {form.is_business && (
+        <div className="space-y-2">
+          <Label htmlFor="vat_number">VAT number (optional)</Label>
+          <Input
+            id="vat_number"
+            value={form.vat_number}
+            onChange={(e) => handleChange('vat_number', e.target.value)}
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="client_email">Email</Label>
+        <Input
+          id="client_email"
+          type="email"
+          value={form.email}
+          onChange={(e) => handleChange('email', e.target.value)}
+        />
+      </div>
+
+      {formError && <p className="text-sm text-red-600">{formError}</p>}
+
+      <div className="flex gap-2 pt-2">
+        <Button type="submit" disabled={submitting}>
+          {submitting ? 'Saving...' : submitLabel}
+        </Button>
+        <Button type="button" variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/hooks/useClients.test.ts
+++ b/src/hooks/useClients.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getClientDisplayName,
+  clientToForm,
+  emptyClientForm,
+} from './useClients'
+import type { Client } from './useClients'
+
+const businessClient: Client = {
+  id: '1',
+  user_id: 'u1',
+  is_business: true,
+  business_name: 'Acme Corp',
+  first_name: null,
+  last_name: null,
+  email: 'acme@test.com',
+  country: 'US',
+  street: '123 Main',
+  city: 'NYC',
+  zip: '10001',
+  vat_number: 'VAT123',
+  created_at: '2026-01-01',
+}
+
+const individualClient: Client = {
+  id: '2',
+  user_id: 'u1',
+  is_business: false,
+  business_name: null,
+  first_name: 'John',
+  last_name: 'Doe',
+  email: 'john@test.com',
+  country: 'UK',
+  street: '456 High St',
+  city: 'London',
+  zip: 'SW1A',
+  vat_number: null,
+  created_at: '2026-01-01',
+}
+
+describe('getClientDisplayName', () => {
+  it('returns business name for business client', () => {
+    expect(getClientDisplayName(businessClient)).toBe('Acme Corp')
+  })
+
+  it('returns full name for individual client', () => {
+    expect(getClientDisplayName(individualClient)).toBe('John Doe')
+  })
+
+  it('returns Unnamed for client with no name', () => {
+    expect(
+      getClientDisplayName({
+        ...individualClient,
+        first_name: null,
+        last_name: null,
+      }),
+    ).toBe('Unnamed')
+  })
+})
+
+describe('clientToForm', () => {
+  it('converts business client to form data', () => {
+    const form = clientToForm(businessClient)
+    expect(form.is_business).toBe(true)
+    expect(form.business_name).toBe('Acme Corp')
+    expect(form.country).toBe('US')
+  })
+
+  it('converts individual client to form data', () => {
+    const form = clientToForm(individualClient)
+    expect(form.is_business).toBe(false)
+    expect(form.first_name).toBe('John')
+    expect(form.last_name).toBe('Doe')
+  })
+})
+
+describe('emptyClientForm', () => {
+  it('has all fields empty/false', () => {
+    expect(emptyClientForm.is_business).toBe(false)
+    expect(emptyClientForm.business_name).toBe('')
+    expect(emptyClientForm.country).toBe('')
+  })
+})

--- a/src/hooks/useClients.ts
+++ b/src/hooks/useClients.ts
@@ -1,0 +1,168 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useAuth0 } from '@auth0/auth0-react'
+
+export interface Client {
+  id: string
+  user_id: string
+  is_business: boolean
+  business_name: string | null
+  first_name: string | null
+  last_name: string | null
+  email: string | null
+  country: string
+  street: string
+  city: string
+  zip: string
+  vat_number: string | null
+  created_at: string
+}
+
+export interface ClientFormData {
+  is_business: boolean
+  business_name: string
+  first_name: string
+  last_name: string
+  email: string
+  country: string
+  street: string
+  city: string
+  zip: string
+  vat_number: string
+}
+
+export const emptyClientForm: ClientFormData = {
+  is_business: false,
+  business_name: '',
+  first_name: '',
+  last_name: '',
+  email: '',
+  country: '',
+  street: '',
+  city: '',
+  zip: '',
+  vat_number: '',
+}
+
+export function clientToForm(client: Client): ClientFormData {
+  return {
+    is_business: client.is_business,
+    business_name: client.business_name || '',
+    first_name: client.first_name || '',
+    last_name: client.last_name || '',
+    email: client.email || '',
+    country: client.country,
+    street: client.street,
+    city: client.city,
+    zip: client.zip,
+    vat_number: client.vat_number || '',
+  }
+}
+
+export function getClientDisplayName(client: Client): string {
+  if (client.is_business && client.business_name) {
+    return client.business_name
+  }
+  return (
+    [client.first_name, client.last_name].filter(Boolean).join(' ') || 'Unnamed'
+  )
+}
+
+export default function useClients() {
+  const { user, getAccessTokenSilently } = useAuth0()
+  const [clients, setClients] = useState<Client[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchClients = useCallback(async () => {
+    if (!user?.sub) return
+    setLoading(true)
+    setError(null)
+
+    try {
+      const token = await getAccessTokenSilently()
+      const res = await fetch(
+        `/api/clients?auth0_id=${encodeURIComponent(user.sub)}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      if (!res.ok) throw new Error('Failed to fetch clients')
+      const data = await res.json()
+      setClients(data.clients)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }, [user?.sub, getAccessTokenSilently])
+
+  const createClient = useCallback(
+    async (formData: ClientFormData) => {
+      if (!user?.sub) return null
+      const token = await getAccessTokenSilently()
+      const res = await fetch('/api/clients', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ auth0_id: user.sub, ...formData }),
+      })
+      if (!res.ok) throw new Error('Failed to create client')
+      const data = await res.json()
+      setClients((prev) => [data.client, ...prev])
+      return data.client as Client
+    },
+    [user?.sub, getAccessTokenSilently],
+  )
+
+  const updateClient = useCallback(
+    async (id: string, formData: ClientFormData) => {
+      if (!user?.sub) return null
+      const token = await getAccessTokenSilently()
+      const res = await fetch('/api/clients', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ auth0_id: user.sub, id, ...formData }),
+      })
+      if (!res.ok) throw new Error('Failed to update client')
+      const data = await res.json()
+      setClients((prev) => prev.map((c) => (c.id === id ? data.client : c)))
+      return data.client as Client
+    },
+    [user?.sub, getAccessTokenSilently],
+  )
+
+  const deleteClient = useCallback(
+    async (id: string) => {
+      if (!user?.sub) return
+      const token = await getAccessTokenSilently()
+      const res = await fetch('/api/clients', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ auth0_id: user.sub, id }),
+      })
+      if (!res.ok) throw new Error('Failed to delete client')
+      setClients((prev) => prev.filter((c) => c.id !== id))
+    },
+    [user?.sub, getAccessTokenSilently],
+  )
+
+  useEffect(() => {
+    fetchClients()
+  }, [fetchClients])
+
+  return {
+    clients,
+    loading,
+    error,
+    createClient,
+    updateClient,
+    deleteClient,
+    refetch: fetchClients,
+  }
+}

--- a/src/pages/Clients.test.tsx
+++ b/src/pages/Clients.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockGetToken = vi.fn().mockResolvedValue('mock-token')
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => ({
+    user: { sub: 'auth0|123' },
+    isAuthenticated: true,
+    isLoading: false,
+    getAccessTokenSilently: mockGetToken,
+  }),
+}))
+
+import Clients from './Clients'
+
+const mockClient = {
+  id: 'c1',
+  user_id: 'u1',
+  is_business: true,
+  business_name: 'Acme Corp',
+  first_name: null,
+  last_name: null,
+  email: 'acme@test.com',
+  country: 'United States',
+  street: '123 Main St',
+  city: 'New York',
+  zip: '10001',
+  vat_number: 'VAT123',
+  created_at: '2026-03-16',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function mockFetchWith(clients: unknown[]) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ clients }),
+  })
+}
+
+describe('Clients', () => {
+  it('shows loading state', () => {
+    globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
+    render(<Clients />)
+    expect(screen.getByText('Loading clients...')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no clients', async () => {
+    mockFetchWith([])
+    render(<Clients />)
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'No clients yet. Create your first client to get started.',
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('renders client list', async () => {
+    mockFetchWith([mockClient])
+    render(<Clients />)
+    await waitFor(() => {
+      expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Business')).toBeInTheDocument()
+    expect(screen.getByText('United States')).toBeInTheDocument()
+    expect(screen.getByText('acme@test.com')).toBeInTheDocument()
+  })
+
+  it('navigates to create form', async () => {
+    mockFetchWith([])
+    render(<Clients />)
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'New Client' }),
+      ).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'New Client' }))
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Client is registered as a business'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('navigates to edit form', async () => {
+    mockFetchWith([mockClient])
+    render(<Clients />)
+    await waitFor(() => {
+      expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByText('Edit'))
+    await waitFor(() => {
+      expect(screen.getByText('Edit Client')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Business name *')).toHaveValue('Acme Corp')
+  })
+})

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -1,8 +1,165 @@
+import { useState } from 'react'
+import useClients, {
+  getClientDisplayName,
+  clientToForm,
+} from '../hooks/useClients'
+import type { Client, ClientFormData } from '../hooks/useClients'
+import ClientForm from '../components/ClientForm'
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card'
+import { Button } from '../components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../components/ui/table'
+import { Badge } from '../components/ui/badge'
+
+type View = 'list' | 'create' | { edit: Client }
+
 export default function Clients() {
+  const { clients, loading, error, createClient, updateClient, deleteClient } =
+    useClients()
+  const [view, setView] = useState<View>('list')
+  const [deleting, setDeleting] = useState<string | null>(null)
+
+  async function handleCreate(data: ClientFormData) {
+    await createClient(data)
+    setView('list')
+  }
+
+  async function handleUpdate(data: ClientFormData) {
+    if (typeof view === 'object' && 'edit' in view) {
+      await updateClient(view.edit.id, data)
+      setView('list')
+    }
+  }
+
+  async function handleDelete(client: Client) {
+    if (!window.confirm(`Delete ${getClientDisplayName(client)}?`)) return
+    setDeleting(client.id)
+    try {
+      await deleteClient(client.id)
+    } finally {
+      setDeleting(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-6">
+        <p className="text-gray-500">Loading clients...</p>
+      </div>
+    )
+  }
+
+  if (view === 'create') {
+    return (
+      <div className="p-6 max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-6">New Client</h1>
+        <Card>
+          <CardContent className="pt-6">
+            <ClientForm
+              onSubmit={handleCreate}
+              onCancel={() => setView('list')}
+              submitLabel="Create Client"
+            />
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (typeof view === 'object' && 'edit' in view) {
+    return (
+      <div className="p-6 max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-6">Edit Client</h1>
+        <Card>
+          <CardContent className="pt-6">
+            <ClientForm
+              initial={clientToForm(view.edit)}
+              onSubmit={handleUpdate}
+              onCancel={() => setView('list')}
+              submitLabel="Update Client"
+            />
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold">Clients</h1>
-      <p className="text-gray-500 mt-2">Client management coming soon.</p>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Clients</h1>
+        <Button onClick={() => setView('create')}>New Client</Button>
+      </div>
+
+      {error && <p className="text-sm text-red-600 mb-4">{error}</p>}
+
+      {clients.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-center text-gray-500 font-normal">
+              No clients yet. Create your first client to get started.
+            </CardTitle>
+          </CardHeader>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Country</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {clients.map((client) => (
+                  <TableRow key={client.id}>
+                    <TableCell className="font-medium">
+                      {getClientDisplayName(client)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={client.is_business ? 'default' : 'secondary'}
+                      >
+                        {client.is_business ? 'Business' : 'Individual'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{client.country}</TableCell>
+                    <TableCell>{client.email || '-'}</TableCell>
+                    <TableCell className="text-right space-x-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setView({ edit: client })}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-red-600 hover:text-red-700"
+                        onClick={() => handleDelete(client)}
+                        disabled={deleting === client.id}
+                      >
+                        {deleting === client.id ? 'Deleting...' : 'Delete'}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Clients page at `/clients` with list, create, edit, and delete views
- `api/clients.ts` Vercel Function with full CRUD (GET/POST/PUT/DELETE), scoped by user
- `ClientForm` reusable component with business/individual toggle, country dropdown, validation
- `useClients` hook for state management (fetch, create, update, delete)
- Utility functions: `getClientDisplayName`, `clientToForm`, `emptyClientForm`
- 41 tests passing (11 new: 5 page tests, 6 utility tests)

## Test plan
- `docker compose up -d` then `vercel dev`
- Navigate to Clients -> verify empty state
- Create a business client -> verify it appears in the list
- Edit the client -> change fields -> save -> verify updates
- Delete the client -> confirm -> verify removed from list
- `npm run test` passes all 41 tests